### PR TITLE
Upgrade to RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 3.0
+dotnet: 3.1
 
 install:
 - dotnet restore

--- a/AdminMenu.cs
+++ b/AdminMenu.cs
@@ -7,7 +7,7 @@ using Etch.OrchardCore.UserProfiles.Profile;
 
 namespace Etch.OrchardCore.UserProfiles
 {
-    [Feature("Constants.Features.Core")]
+    [Feature(Constants.Features.Core)]
     public class AdminMenu : INavigationProvider
     {
         public AdminMenu(IStringLocalizer<AdminMenu> localizer)

--- a/Etch.OrchardCore.UserProfiles.csproj
+++ b/Etch.OrchardCore.UserProfiles.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.3-rc1</Version>
+    <Version>0.3.0-rc2</Version>
     <PackageId>Etch.OrchardCore.UserProfiles</PackageId>
     <Title>User Profiles</Title>
     <Authors>Etch UK</Authors>
@@ -14,14 +14,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Users" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Users.Abstractions" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Users" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Users.Abstractions" Version="1.0.0-rc2-13450" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GroupField/Drivers/ProfileGroupFieldSettingsDriver.cs
+++ b/GroupField/Drivers/ProfileGroupFieldSettingsDriver.cs
@@ -15,20 +15,20 @@ namespace Etch.OrchardCore.UserProfiles.GroupField.Drivers
 
         public override IDisplayResult Edit(ContentPartFieldDefinition partFieldDefinition)
         {
-            return Initialize<EditProfileGroupFieldSettingsViewModel>("ProfileGroupFieldSettings_Edit", model =>
+            return Initialize<ProfileGroupFieldSettings>("ProfileGroupFieldSettings_Edit", model =>
             {
-                partFieldDefinition.Settings.Populate(model);
+                partFieldDefinition.PopulateSettings<ProfileGroupFieldSettings>(model);
             })
             .Location("Content");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentPartFieldDefinition partFieldDefinition, UpdatePartFieldEditorContext context)
         {
-            var model = new EditProfileGroupFieldSettingsViewModel();
+            var model = new ProfileGroupFieldSettings();
 
             if (await context.Updater.TryUpdateModelAsync(model, Prefix))
             {
-                context.Builder.MergeSettings(model);
+                context.Builder.WithSettings(model);
             }
 
             return Edit(partFieldDefinition);

--- a/GroupField/Startup.cs
+++ b/GroupField/Startup.cs
@@ -33,9 +33,9 @@ namespace Etch.OrchardCore.UserProfiles.GroupField
 
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<ContentField, ProfileGroupField>();
+            services.AddContentField<ProfileGroupField>()
+                .UseDisplayDriver<ProfileGroupFieldDisplayDriver>();
 
-            services.AddScoped<IContentFieldDisplayDriver, ProfileGroupFieldDisplayDriver>();
             services.AddScoped<IContentPartFieldDefinitionDisplayDriver, ProfileGroupFieldSettingsDriver>();
 
             services.AddScoped<IContentPickerResultProvider, ProfileGroupPickerResultProvider>();

--- a/GroupField/ViewModels/EditProfileGroupFieldSettingsViewModel.cs
+++ b/GroupField/ViewModels/EditProfileGroupFieldSettingsViewModel.cs
@@ -1,9 +1,0 @@
-﻿namespace Etch.OrchardCore.UserProfiles.GroupField.ViewModels
-{
-    public class EditProfileGroupFieldSettingsViewModel
-    {
-        public string Hint { get; set; }
-        public bool Multiple { get; set; }
-        public bool Required { get; set; }
-    }
-}

--- a/GroupOwnership/Drivers/ProfileGroupOwnershipPartDisplay.cs
+++ b/GroupOwnership/Drivers/ProfileGroupOwnershipPartDisplay.cs
@@ -109,23 +109,28 @@ namespace Etch.OrchardCore.UserProfiles.GroupOwnership.Drivers
 
         private bool ShouldRestrictAccess(ProfileGroupOwnershipPart part, BuildPartDisplayContext context)
         {
-            var settings = context.TypePartDefinition.Settings.ToObject<ProfileGroupOwnershipPartSettings>();
+            var settings = context.TypePartDefinition.GetSettings<ProfileGroupOwnershipPartSettings>();
+
             if (settings == null)
             {
                 return false;
             }
+
             if (settings.RestrictAccess == RestrictAccess.None)
             {
                 return false;
             }
+
             if (settings.RestrictAccess == RestrictAccess.ForType)
             {
                 return true;
             }
+
             if (settings.RestrictAccess == RestrictAccess.SetPerItem)
             {
                 return part.RestrictAccess;
             }
+
             return false;
         }
 

--- a/GroupOwnership/Drivers/ProfileGroupOwnershipPartSettingsDisplay.cs
+++ b/GroupOwnership/Drivers/ProfileGroupOwnershipPartSettingsDisplay.cs
@@ -24,9 +24,7 @@ namespace Etch.OrchardCore.UserProfiles.GroupOwnership.Drivers
 
             return Initialize<ProfileGroupOwnershipPartSettingsViewModel>("ProfileGroupOwnershipPartSettings_Edit", model =>
             {
-                var settings = contentTypePartDefinition.Settings.ToObject<ProfileGroupOwnershipPartSettings>();
-
-                model.RestrictAccess = settings.RestrictAccess;
+                model.RestrictAccess = contentTypePartDefinition.GetSettings<ProfileGroupOwnershipPartSettings>().RestrictAccess;
             }).Location("Content");
         }
 
@@ -39,10 +37,12 @@ namespace Etch.OrchardCore.UserProfiles.GroupOwnership.Drivers
 
             var model = new ProfileGroupOwnershipPartSettingsViewModel();
 
-            if (await context.Updater.TryUpdateModelAsync(model, Prefix, m => m.RestrictAccess))
+            await context.Updater.TryUpdateModelAsync(model, Prefix, m => m.RestrictAccess);
+
+            context.Builder.WithSettings(new ProfileGroupOwnershipPartSettings
             {
-                context.Builder.WithSetting(nameof(ProfileGroupOwnershipPartSettings.RestrictAccess), model.RestrictAccess.ToString());
-            }
+                RestrictAccess = model.RestrictAccess
+            });
 
             return Edit(contentTypePartDefinition, context.Updater);
         }

--- a/GroupOwnership/Migrations.cs
+++ b/GroupOwnership/Migrations.cs
@@ -36,9 +36,10 @@ namespace Etch.OrchardCore.UserProfiles.GroupOwnership
                     .OfType(nameof(ProfileGroupField))
                     .WithDisplayName("Owned by group")
                     .WithDescription("Specifies which group owns the current content")
-                    .WithSetting("Hint", "Which group owns this content")
-                    .WithSetting("Required", "false")
-                    .WithSetting("DisplayMode", "Zero")
+                    .WithSettings(new ProfileGroupFieldSettings
+                    {
+                        Hint = "Which group owns this content."
+                    })
                 ));
 
             SchemaBuilder.CreateMapIndexTable(nameof(GroupOwnershipIndex), table => table

--- a/GroupOwnership/Services/OwnershipAuthorizationService.cs
+++ b/GroupOwnership/Services/OwnershipAuthorizationService.cs
@@ -56,7 +56,7 @@ namespace Etch.OrchardCore.UserProfiles.GroupOwnership.Services
             }
 
             // If logged in user is an admin of CMS can view the content
-            if (await _authorizationService.AuthorizeAsync(userPrincipal, Permissions.EditContent))
+            if (await _authorizationService.AuthorizeAsync(userPrincipal, CommonPermissions.EditContent))
             {
                 return true;
             }

--- a/GroupOwnership/Startup.cs
+++ b/GroupOwnership/Startup.cs
@@ -21,12 +21,12 @@ namespace Etch.OrchardCore.UserProfiles.GroupOwnership
 
             services.AddScoped<IDataMigration, Migrations>();
 
-            services.AddScoped<IContentPartDisplayDriver, ProfileGroupOwnershipPartDisplay>();
+            services.AddContentPart<ProfileGroupOwnershipPart>()
+                .UseDisplayDriver<ProfileGroupOwnershipPartDisplay>();
+
             services.AddScoped<IContentTypePartDefinitionDisplayDriver, ProfileGroupOwnershipPartSettingsDisplay>();
 
             services.AddScoped<IOwnershipAuthorizationService, OwnershipAuthorizationService>();
-
-            services.AddSingleton<ContentPart, ProfileGroupOwnershipPart>();
         }
     }
 }

--- a/Grouping/Startup.cs
+++ b/Grouping/Startup.cs
@@ -24,12 +24,13 @@ namespace Etch.OrchardCore.UserProfiles.Grouping
             services.AddSingleton<IIndexProvider, ProfileGroupPartIndexProvider>();
             services.AddSingleton<IIndexProvider, ProfileGroupedPartIndexProvider>();
 
-            services.AddScoped<IContentPartDisplayDriver, ProfileGroupPartDisplay>();
+            services.AddContentPart<ProfileGroupPart>()
+                .UseDisplayDriver<ProfileGroupPartDisplay>();
+
+            services.AddContentPart<ProfileGroupedPart>();
+
             services.AddScoped<IContentTypePartDefinitionDisplayDriver, ProfileGroupPartSettingsDisplayDriver>();
             services.AddScoped<IProfileGroupsService, ProfileGroupsService>();
-
-            services.AddSingleton<ContentPart, ProfileGroupedPart>();
-            services.AddSingleton<ContentPart, ProfileGroupPart>();
 
             services.AddScoped<IContentPickerResultProvider, ProfilePickerResultProvider>();
 

--- a/Handlers/ProfilePartHandler.cs
+++ b/Handlers/ProfilePartHandler.cs
@@ -12,7 +12,6 @@ namespace Etch.OrchardCore.UserProfiles.Handlers
 {
     public class ProfilePartHandler : ContentPartHandler<ProfilePart>
     {
-
         #region Dependencies
 
         private readonly IAuthorizationService _authorizationService;
@@ -55,6 +54,5 @@ namespace Etch.OrchardCore.UserProfiles.Handlers
         }
 
         #endregion
-
     }
 }

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -6,7 +6,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Users",
     Description = "Adds profiles for users",
     Name = "User Profiles",
-    Version = "0.2.3",
+    Version = "0.3.0",
     Website = "https://etchuk.com"
 )]
 
@@ -14,7 +14,8 @@ using OrchardCore.Modules.Manifest;
     Id = Constants.Features.Core,
     Name = "Profiles",
     Category = "Users",
-    Description = "Adds profiles for users."
+    Description = "Adds profiles for users.",
+    Dependencies = new string[] { Constants.Features.Grouping }
 )]
 
 [assembly: Feature(

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -39,7 +39,7 @@ namespace Etch.OrchardCore.UserProfiles
 
         #region Migrations
 
-        public async Task<int> CreateAsync()
+        public int Create()
         {
             _contentDefinitionManager.AlterPartDefinition("ProfilePart", builder => builder
                 .WithDescription("Links content item to user.")

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) that provid
 
 ## Orchard Core Reference
 
-This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
+This module is referencing the RC2 build of Orchard Core ([`1.0.0-rc2-13450`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc2-13450)).
 
 ## Installing
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -28,9 +28,9 @@ namespace Etch.OrchardCore.UserProfiles
         public override void ConfigureServices(IServiceCollection services)
         {
             // Profile Part
-            services.AddScoped<IContentPartDisplayDriver, ProfilePartDisplay>();
-            services.AddSingleton<ContentPart, ProfilePart>();
-            services.AddScoped<IContentPartHandler, ProfilePartHandler>();
+            services.AddContentPart<ProfilePart>()
+                .UseDisplayDriver<ProfilePartDisplay>()
+                .AddHandler<ProfilePartHandler>();
 
             services.AddScoped<IProfileService, ProfileService>();
             services.AddScoped<IURLService, URLService>();

--- a/SubscriptionAccessGrouping/AdminMenu.cs
+++ b/SubscriptionAccessGrouping/AdminMenu.cs
@@ -4,11 +4,12 @@ using Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Drivers;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Navigation;
 
-namespace UKIE.OrchardCore.UserProfiles.SubscriptionAccessGrouping
+namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping
 {
-
-    public class AdminMenu : INavigationProvider {
-        public AdminMenu(IStringLocalizer<AdminMenu> localizer) {
+    public class AdminMenu : INavigationProvider 
+    {
+        public AdminMenu(IStringLocalizer<AdminMenu> localizer) 
+        {
             T = localizer;
         }
 
@@ -22,11 +23,10 @@ namespace UKIE.OrchardCore.UserProfiles.SubscriptionAccessGrouping
             builder
                 .Add(T["Configuration"], configuration => configuration
                     .Add(T["Subscriptions"], settings => settings
-                        .Add(T["Security"], T["Security"], layers => layers
-                            .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = SubscriptionAccessSettingsDisplay.GroupId })
-                            .Permission(Permissions.ManageSubscription)
-                            .LocalNav()
-                        )));
+                        .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = SubscriptionAccessSettingsDisplay.GroupId })
+                        .Permission(Permissions.ManageSubscription)
+                        .LocalNav()
+                    ));
 
             return Task.CompletedTask;
         }

--- a/SubscriptionAccessGrouping/Drivers/AccessAuthorizationService.cs
+++ b/SubscriptionAccessGrouping/Drivers/AccessAuthorizationService.cs
@@ -9,14 +9,14 @@ using Etch.OrchardCore.UserProfiles.Subscriptions.Models;
 using Etch.OrchardCore.UserProfiles.Subscriptions.Services;
 using Microsoft.AspNetCore.Authorization;
 using OrchardCore.ContentManagement;
+using OrchardCore.Contents;
 using OrchardCore.Users.Services;
-using Permissions = OrchardCore.Contents.Permissions;
+using Permissions = OrchardCore.Contents.CommonPermissions;
 
 namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Drivers
 {
     public class AccessAuthorizationService : IAccessAuthorizationService
     {
-
         #region Dependencies
 
         private readonly IAuthorizationService _authorizationService;
@@ -54,7 +54,7 @@ namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Drivers
             subscriptionAccessSelection = subscriptionAccessSelection.Where(x => x.IsSelected).ToArray();
 
             // If logged in user is an admin of CMS can view the content
-            if (await _authorizationService.AuthorizeAsync(userPrincipal, Permissions.EditContent)) {
+            if (await _authorizationService.AuthorizeAsync(userPrincipal, CommonPermissions.EditContent)) {
                 return true;
             }
 

--- a/SubscriptionAccessGrouping/Drivers/SubscriptionAccessGroupingPartDisplay.cs
+++ b/SubscriptionAccessGrouping/Drivers/SubscriptionAccessGroupingPartDisplay.cs
@@ -67,6 +67,5 @@ namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Drivers
         }
 
         #endregion
-
     }
 }

--- a/SubscriptionAccessGrouping/Drivers/SubscriptionAccessSettingsDisplay.cs
+++ b/SubscriptionAccessGrouping/Drivers/SubscriptionAccessSettingsDisplay.cs
@@ -8,8 +8,6 @@ using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Settings;
 
-using Permissions = UKIE.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Permissions;
-
 namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Drivers
 {
     public class SubscriptionAccessSettingsDisplay : SectionDisplayDriver<ISite, SubscriptionAccessSettings>
@@ -47,7 +45,7 @@ namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Drivers
                 return null;
             }
 
-            return Initialize<SubscriptionAccessSettingsViewModel>("SubscriptionAccessSettings_Edit", async model =>
+            return Initialize<SubscriptionAccessSettingsViewModel>("SubscriptionAccessSettings_Edit", model =>
             {
                 model.UnauthorisedRedirectPath = settings.UnauthorisedRedirectPath;
 

--- a/SubscriptionAccessGrouping/Permissions.cs
+++ b/SubscriptionAccessGrouping/Permissions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace UKIE.OrchardCore.UserProfiles.SubscriptionAccessGrouping
+namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping
 {
     public class Permissions : IPermissionProvider
     {

--- a/SubscriptionAccessGrouping/Startup.cs
+++ b/SubscriptionAccessGrouping/Startup.cs
@@ -1,16 +1,15 @@
 ﻿using Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Drivers;
 using Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Services;
 using Etch.OrchardCore.UserProfiles.SubscriptionGroups.Services;
+using Etch.OrchardCore.UserProfiles.Subscriptions.Models;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings;
-
-using AdminMenu = UKIE.OrchardCore.UserProfiles.SubscriptionAccessGrouping.AdminMenu;
-using Permissions = UKIE.OrchardCore.UserProfiles.SubscriptionAccessGrouping.Permissions;
 
 namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping
 {
@@ -24,7 +23,10 @@ namespace Etch.OrchardCore.UserProfiles.SubscriptionAccessGrouping
             services.AddScoped<IPermissionProvider, Permissions>();
             services.AddScoped<ISubscriptionAccessSettingsService, SubscriptionAccessSettingsService>();
             services.AddScoped<IAccessAuthorizationService, AccessAuthorizationService>();
-            services.AddScoped<IContentPartDisplayDriver, SubscriptionAccessGroupingPartDisplay>();
+
+            services.AddContentPart<SubscriptionAccessPart>()
+                 .UseDisplayDriver<SubscriptionAccessGroupingPartDisplay>();
+
             services.AddScoped<ISubscriptionGroupsService, SubscriptionGroupsService>();
         }
     }

--- a/SubscriptionGroups/Drivers/SubscriptionGroupPartDisplay.cs
+++ b/SubscriptionGroups/Drivers/SubscriptionGroupPartDisplay.cs
@@ -9,7 +9,6 @@ namespace Etch.OrchardCore.UserProfiles.Subscriptions.Drivers
 {
     public class SubscriptionGroupPartDisplay : ContentPartDisplayDriver<SubscriptionGroupPart>
     {
-
         #region Overrides
 
         public override IDisplayResult Edit(SubscriptionGroupPart part)
@@ -17,8 +16,6 @@ namespace Etch.OrchardCore.UserProfiles.Subscriptions.Drivers
             return Initialize<SubscriptionGroupPartEditViewModel>("SubscriptionGroupPart_Edit", model =>
             {
                 model.Identifier = part.Identifier;
-
-                return Task.CompletedTask;
             });
         }
 

--- a/SubscriptionGroups/Drivers/SubscriptionGroupSelectPartDisplay.cs
+++ b/SubscriptionGroups/Drivers/SubscriptionGroupSelectPartDisplay.cs
@@ -38,8 +38,10 @@ namespace Etch.OrchardCore.UserProfiles.Subscriptions.Drivers
 
         public override async Task<IDisplayResult> EditAsync(SubscriptionGroupSelectPart part, BuildPartEditorContext context)
         {
-            return Initialize<SubscriptionGroupSelectPartViewModel>("SubscriptionGroupSelectPart_Edit", async model => {
-                model.SubscriptionGroups = await _subscriptionGroupsService.GetAllAsync();
+            var subscriptionGroups = await _subscriptionGroupsService.GetAllAsync();
+
+            return Initialize<SubscriptionGroupSelectPartViewModel>("SubscriptionGroupSelectPart_Edit", model => {
+                model.SubscriptionGroups = subscriptionGroups;
                 model.SubscriptionGroup = part.SubscriptionGroup;
                 return;
             });

--- a/SubscriptionGroups/Startup.cs
+++ b/SubscriptionGroups/Startup.cs
@@ -15,16 +15,17 @@ namespace Etch.OrchardCore.UserProfiles.SubscriptionGroups
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddScoped<IContentPartDisplayDriver, SubscriptionGroupPartDisplay>();
-            services.AddScoped<IContentPartDisplayDriver, SubscriptionGroupSelectPartDisplay>();
-            services.AddScoped<IContentPartDisplayDriver, SubscriptionGroupAccessPartDisplay>();
+            services.AddContentPart<SubscriptionGroupPart>()
+                .UseDisplayDriver<SubscriptionGroupPartDisplay>();
+
+            services.AddContentPart<SubscriptionGroupSelectPart>()
+                .UseDisplayDriver<SubscriptionGroupSelectPartDisplay>();
+
+            services.AddContentPart<SubscriptionGroupAccessPart>()
+                .UseDisplayDriver<SubscriptionGroupAccessPartDisplay>();
 
             services.AddScoped<ISubscriptionGroupsService, SubscriptionGroupsService>();
             services.AddScoped<ISubscriptionGroupPartService, SubscriptionGroupPartService>();
-
-            services.AddSingleton<ContentPart, SubscriptionGroupPart>();
-            services.AddSingleton<ContentPart, SubscriptionGroupSelectPart>();
-            services.AddSingleton<ContentPart, SubscriptionGroupAccessPart>();
 
             services.AddScoped<IDataMigration, Migrations>();
         }

--- a/Subscriptions/Drivers/SubscriptionPartDisplay.cs
+++ b/Subscriptions/Drivers/SubscriptionPartDisplay.cs
@@ -17,8 +17,6 @@ namespace Etch.OrchardCore.UserProfiles.Subscriptions.Drivers
             return Initialize<SubscriptionPartEditViewModel>("SubscriptionPart_Edit", model =>
             {
                 model.Identifier = part.Identifier;
-
-                return Task.CompletedTask;
             });
         }
 

--- a/Subscriptions/Services/SubscriptionLevelService.cs
+++ b/Subscriptions/Services/SubscriptionLevelService.cs
@@ -30,7 +30,7 @@ namespace Etch.OrchardCore.UserProfiles.Subscriptions.Services
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(subscriptionLevelPart.ContentItem.ContentType);
             var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(SubscriptionLevelPart), StringComparison.Ordinal));
-            return contentTypePartDefinition.Settings.ToObject<SubscriptionLevelPartSettings>();
+            return contentTypePartDefinition.GetSettings<SubscriptionLevelPartSettings>();
         }
 
         #endregion

--- a/Subscriptions/Settings/SubscriptionLevelPartSettingsDriver.cs
+++ b/Subscriptions/Settings/SubscriptionLevelPartSettingsDriver.cs
@@ -33,12 +33,11 @@ namespace Etch.OrchardCore.UserProfiles.Subscriptions.Settings
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
         {
-            var model = new EditSubscriptionLevelPartSettingsViewModel();
+            var model = new SubscriptionLevelPartSettings();
 
             await context.Updater.TryUpdateModelAsync(model, Prefix, m => m.Hint, m => m.Multiple);
 
-            context.Builder.WithSetting(nameof(SubscriptionLevelPartSettings.Hint), model.Hint);
-            context.Builder.WithSetting(nameof(SubscriptionLevelPartSettings.Multiple), model.Multiple.ToString());
+            context.Builder.WithSettings(model);
 
             return Edit(contentTypePartDefinition, context.Updater);
         }

--- a/Subscriptions/Startup.cs
+++ b/Subscriptions/Startup.cs
@@ -16,19 +16,22 @@ namespace Etch.OrchardCore.UserProfiles.Subscriptions
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddScoped<IContentPartDisplayDriver, SubscriptionPartDisplay>();
-            services.AddScoped<IContentPartDisplayDriver, SubscriptionLevelPartDisplay>();
-            services.AddScoped<IContentPartDisplayDriver, SubscriptionAccessPartDisplay>();
+            services.AddContentPart<SubscriptionPart>()
+                .UseDisplayDriver<SubscriptionPartDisplay>();
+
+            services.AddContentPart<SubscriptionLevelPart>()
+                .UseDisplayDriver<SubscriptionLevelPartDisplay>();
+
+            services.AddContentPart<SubscriptionAccessPart>()
+                .UseDisplayDriver<SubscriptionAccessPartDisplay>();
+
             services.AddScoped<ISubscriptionsService, SubscriptionsService>();
             services.AddScoped<ISubscriptionPartService, SubscriptionPartService>();
             services.AddScoped<ISubscriptionLevelService, SubscriptionLevelService>();
+
             services.AddScoped<IDataMigration, Migrations>();
+
             services.AddScoped<IContentTypePartDefinitionDisplayDriver, SubscriptionLevelPartSettingsDriver>();
-
-            services.AddSingleton<ContentPart, SubscriptionPart>();
-            services.AddSingleton<ContentPart, SubscriptionLevelPart>();
-            services.AddSingleton<ContentPart, SubscriptionAccessPart>();
-
         }
     }
 }

--- a/Views/ProfileGroupFieldSettings.Edit.cshtml
+++ b/Views/ProfileGroupFieldSettings.Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@model Etch.OrchardCore.UserProfiles.GroupField.ViewModels.EditProfileGroupFieldSettingsViewModel
+﻿@model Etch.OrchardCore.UserProfiles.GroupField.Models.ProfileGroupFieldSettings
 
 <fieldset class="form-group">
     <div class="row col-sm-6">

--- a/Views/ProfileGroupOwnershipPartSettings.Edit.cshtml
+++ b/Views/ProfileGroupOwnershipPartSettings.Edit.cshtml
@@ -6,13 +6,9 @@
     <div class="col-md-8">
         <label asp-for="RestrictAccess">@T["Restrict access"]</label>
         <select asp-for="RestrictAccess" class="custom-select">
-            <option value="@RestrictAccess.None">@T["None"]</option>
-            <option value="@RestrictAccess.ForType">@T["Type"]</option>
-            <option value="@RestrictAccess.SetPerItem">@T["Item"]</option>
+            <option value="@RestrictAccess.None">@T["None - Never restrict access"]</option>
+            <option value="@RestrictAccess.ForType">@T["Type - Always restrict access for all items of this type that have a group owner"]</option>
+            <option value="@RestrictAccess.SetPerItem">@T["Content Item - Display option when editing to restrict access for content items of this type"]</option>
         </select>
-        <p class="hint">@T["Sets if the group ownership limits access to items:"]</p>
-        <p class="hint">@T["None - Never restrict access."]</p>
-        <p class="hint">@T["Type - Always restrict access for all items of this type that have a group owner."]</p>
-        <p class="hint">@T["Item - Display option when editing to restrict access for items of this type."]</p>
     </div>
 </div>

--- a/Views/ProfilePart.Edit.cshtml
+++ b/Views/ProfilePart.Edit.cshtml
@@ -13,6 +13,6 @@
     <span asp-validation-for="UserName"></span>
     @if (Model.Id != 0)
     {
-        <span class="hint">@T["Username of linked user."] <a href="@(Model.SiteURL == "/" ? Model.SiteURL : string.Format("{0}/", Model.SiteURL))OrchardCore.Users/Admin/Edit/@Model.Id">View User</a></span>
+        <span class="hint">@T["Username of linked user."] <a href="@(Model.SiteURL == "/" ? Model.SiteURL : string.Format("{0}/", Model.SiteURL))Admin/Users/Edit/@Model.Id">View User</a></span>
     }
 </fieldset>

--- a/nuget.config
+++ b/nuget.config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="OrchardCorePreview" value="https://www.myget.org/F/orchardcore-preview/api/v3/index.json" />
-  </packageSources>
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
-</configuration>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.userprofiles",
-    "version": "0.2.3",
+    "version": "0.3.0",
     "description": "Module for Orchard Core that provides profiles for users.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
- Update target framework to 3.1
- Update Orchard Core dependencies to RC2
- Update travis build script to target 3.1
- Remove `nuget.config` pointing to preview feed
- Fix URL to edit user
- Update parts/driver definitions in `Startup` to use `AddContentPart` and `UseDisplayDriver`
- Fix a handful of incorrect namespaces, which were causing admin menu's to not show
- Change level of subscription admin menu option
- Update fetching/updating settings to use new methods introduced in RC1

There are a handful of issues (linked below) that have been added but Ididn't want to resolve in this update, as the primary concern is making the module work with RC2.

https://github.com/EtchUK/Etch.OrchardCore.UserProfiles/issues/5
https://github.com/EtchUK/Etch.OrchardCore.UserProfiles/issues/6
https://github.com/EtchUK/Etch.OrchardCore.UserProfiles/issues/7